### PR TITLE
Adds ZMQ (and redis)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+pkg/
+src/github.com/
+src/golang.org/
+src/gopkg.in/
+src/leb.io/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Without make:
   anglova [command]
 
 Available Commands:
+  broker      Start a ZMQ broker
   help        Help about any command
   publish     Publish to a topic
   pubsub      Publish and subscribe to a topic

--- a/src/ihmc.us/anglova/cmd/broker.go
+++ b/src/ihmc.us/anglova/cmd/broker.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	zmq "github.com/pebbe/zmq4"
+	"github.com/spf13/cobra"
+	"strconv"
+	"time"
+)
+
+func init() {
+	RootCmd.AddCommand(brokerCmd)
+}
+
+var brokerCmd = &cobra.Command{
+	Use:   "broker",
+	Short: "Start a ZMQ broker",
+	Long:  "Starts a ZMQ broker than can be used to publish and subscribe to",
+	Run: func(cmd *cobra.Command, args []string) {
+		var publishPort int
+		var publishHost string
+		var receiverHost string
+		var err error
+
+		receiverHost = fmt.Sprintf("tcp://*:%s", cfg.BrokerPort)
+
+		if publishPort, err = strconv.Atoi(cfg.BrokerPort); err == nil {
+			publishHost = fmt.Sprintf("tcp://*:%d", publishPort+1)
+		} else {
+			log.Fatal("Unable to create ZMQ broker ", err)
+		}
+
+		context, _ := zmq.NewContext()
+		receiver, _ := context.NewSocket(zmq.PULL)
+		receiver.Bind(receiverHost)
+		log.Info("Bound receiver on " + receiverHost)
+		sender, _ := context.NewSocket(zmq.PUB)
+		sender.Bind(publishHost)
+		log.Info("Bound publisher on " + publishHost)
+
+		log.Info("Waiting for messages...")
+
+		last := time.Now()
+		messages := 0
+		quiet := true
+		for {
+			message, err := receiver.RecvMessageBytes(0)
+			if err != nil {
+				log.Error("Error receiving messages", err)
+			}
+			sender.SendMessage(message)
+			if !quiet {
+				messages += 1
+				now := time.Now()
+				if now.Sub(last).Seconds() > 1 {
+					log.Info(messages, "msg/sec")
+					last = now
+					messages = 0
+				}
+			}
+
+		}
+	},
+}

--- a/src/ihmc.us/anglova/protocol/proto.go
+++ b/src/ihmc.us/anglova/protocol/proto.go
@@ -7,4 +7,6 @@ const (
 	MQTT     = "mqtt"
 	Kafka    = "kafka"
 	IPFS     = "ipfs"
+	ZMQ      = "zeromq"
+	Redis    = "redis"
 )

--- a/src/ihmc.us/anglova/pubsub/pub.go
+++ b/src/ihmc.us/anglova/pubsub/pub.go
@@ -2,7 +2,7 @@ package pubsub
 
 import (
 	"errors"
-	_ "github.com/Shopify/sarama"
+	"github.com/Shopify/sarama"
 	log "github.com/Sirupsen/logrus"
 	"github.com/streadway/amqp"
 	"ihmc.us/anglova/conn"
@@ -11,11 +11,6 @@ import (
 	"math/rand"
 	"sync/atomic"
 	"time"
-	//"github.com/Shopify/sarama"
-	"github.com/Shopify/sarama"
-	"ihmc.us/anglova/conn"
-	"ihmc.us/anglova/msg"
-	"ihmc.us/anglova/protocol"
 )
 
 type Pub struct {
@@ -28,7 +23,7 @@ func NewPub(protocol string, host string, port string, topic string) (*Pub, erro
 	id := rand.Uint32() + uint32(time.Now().Nanosecond())
 
 	//create the connection
-	connection, err := conn.New(protocol, host, port, topic)
+	connection, err := conn.New(protocol, host, port, topic, true)
 	if err != nil {
 		log.Error("Error during the connection with the broker!")
 		return nil, err
@@ -90,7 +85,7 @@ func (pub *Pub) Publish(topic string, buf []byte) error {
 	case protocol.IPFS:
 		err = pub.conn.IPFSClient.PubSubPublish(topic, string(buf[:]))
 	case protocol.ZMQ:
-		_, err = pub.conn.ZMQClient.Pub.Send(topic+" "+string(buf[:]), 0)
+		_, err = pub.conn.ZMQClient.SendMessage(topic, buf)
 	case protocol.Redis:
 		pub.conn.RedisClient.Lock()
 		pub.conn.RedisClient.Conn.Send("PUBLISH", topic, buf)


### PR DESCRIPTION
This PR adds ZMQ to the mix of protocols:

* support for `--protocol zeromq`
* adds the `broker` command to start a ZMQ broker

The ZMQ broker listens on `--port <num>` for published messages and forwards these message to subscribers that have subscribed to `--port <num+1>`. `anglova subscribe --protocol zeromq` will automatically subscribe to `--port <num+1>` where `anglove publish --protocol zeromq` will publish to `--port <num>`.

I've also added support for redis which was not planned but would be nice to try anyway. This requires a redis-server to run somewhere.

I've did some testing using the `publish` and `subscribe` commands which seems to be working for both protocols but as I do not have a good understanding how test should be run there still maybe some errors there. ZMQ seems to receive all messages where redis seems to be missing some messages.